### PR TITLE
Arreglado problema con delay del comando 'top' en raspberry pi 3

### DIFF
--- a/system_monitor.js
+++ b/system_monitor.js
@@ -26,7 +26,7 @@ execHandler("uname -r")
   .then(stdout => saveData('kernel', stdout))
   .catch(errorHandler);
 
-execHandler("top -d 0.5 -b -n2 | tail -n 10 | awk '{print $12}'")
+execHandler("top -d 1 -b -n2 | tail -n 10 | awk '{print $12}'")
   .then(stdout => saveData('toplist', stdout))
   .catch(errorHandler);
 
@@ -81,7 +81,7 @@ setInterval(function() {
       .then(stdout => saveData('toplist', stdout.split("\n").filter(item => item)))
       .catch(errorHandler);
 
-    execHandler("top -d 0.5 -b -n2 | grep 'Cpu(s)'|tail -n 1 | awk '{print $2 + $4}'")
+    execHandler("top -d 1 -b -n2 | grep 'Cpu(s)'|tail -n 1 | awk '{print $2 + $4}'")
       .then(stdout => {
         const date = new Date().getTime();
         saveData('cpuUsageUpdate', {date, use: parseFloat(stdout)});


### PR DESCRIPTION
Si en el comando 'top' había un delay con número flotante (por ejemplo 0.5) petaba y no actualizaba. He correjido cambiando el delay a 1 seg y funciona ok!